### PR TITLE
Refactor: Improve install dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,15 @@ url = https://github.com/HIP-infrastructure/bids-converter
 [options]
 python_requires = >=3.8
 install_requires =
+    bids_manager @ git+https://github.com/HIP-infrastructure/BIDS_Manager.git@dev
     pandas == 1.3.5
     pybids >= 0.15.3
     scipy >= 1.6
 
 test_requires =
     pytest
+    pytest-console-scripts
+    pytest-cov
 
 packages = find:
 
@@ -33,9 +36,14 @@ packages = find:
 [options.extras_require]
 doc =
     pydot >= 1.2.3
-    sphinx >= 1.8
-    sphinx-argparse
-    sphinx_rtd_theme
+    sphinx >= 6.1.3
+    sphinx-argparse == 0.4.0
+    sphinx_rtd_theme == 1.2.0
+    recommonmark == 0.7.1
+    sphinxcontrib-apidoc == 0.3.0
+    nbsphinx == 0.8.12
+    sphinxemoji == 0.2.0
+    mock == 5.0.1
 dev =
     black ~= 22.3.0
     pre-commit


### PR DESCRIPTION
This PR simplifies the installation of the dependencies of the package including bids_manager and so simplifies the Dockerfile. We still need to install versioneer and the dependencies of bids_manager which are/can still not installed automatically. 