### PR TITLE
ci: use only github url for semantic-release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,6 @@ release:
     - if: '$CI_COMMIT_REF_NAME == "master"'
     - if: '$CI_COMMIT_REF_NAME == "dev"'
   script:
-    - GL_TOKEN=$GL_TOKEN GH_TOKEN=$GH_TOKEN npx semantic-release
+    - GL_TOKEN=$GL_TOKEN GH_TOKEN=$GH_TOKEN npx semantic-release -r 
     - make build-docker TAG=$(python get_version.py)
     - make push-docker-ci TAG=$(python get_version.py)

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,7 @@
       "prerelease": true
     }
   ],
+  "repositoryUrl": "https://github.com/HIP-infrastructure/bids-converter",
   "plugins": [
     "@semantic-release/commit-analyzer",
     [
@@ -59,7 +60,6 @@
     [
       "@semantic-release/github",
       {
-        "githubUrl": "https://github.com/HIP-infrastructure/bids-converter",
         "assets": [
           {
             "path": "dist/*.tar.gz",


### PR DESCRIPTION
Part of Prs for:
- #23 