### PR TITLE
feat: update the CHANGES file of a BIDS dataset at version tag creation

### DIFF
--- a/datahipy/bids/version.py
+++ b/datahipy/bids/version.py
@@ -3,6 +3,8 @@
 
 """Utility functions to retrieve version related information from a BIDS dataset."""
 
+import os
+from datetime import date
 from packaging import version
 from datahipy.bids.const import BIDS_VERSION
 
@@ -37,3 +39,48 @@ def determine_bids_schema_version(dataset_desc):
     else:
         bids_schema_version = BIDS_VERSION
     return bids_schema_version
+
+
+def create_bids_changes_tag_entry(tag, changes_list):
+    """Create a release text block entry to be added to the CHANGES file of a BIDS dataset.
+
+    Parameters
+    ----------
+    tag : str
+        Tag of the dataset.
+
+    changes_list : list
+        List of changes to add to the `CHANGES` file.
+
+    Returns
+    -------
+    list
+        List of lines to be written to the `CHANGES` file.
+    """
+    return [
+        f"{tag} {date.today().strftime('%Y-%m-%d')}\n",
+        "\n\t- " + "\n\t- ".join(changes_list),
+        "\n\n",
+    ]
+
+
+def update_bids_changes(bids_dir, changes_tag_entry):
+    """Append a new release text block to the top to the `CHANGES` file of a BIDS dataset.
+
+    Parameters
+    ----------
+    bids_dir : str
+        Path to the BIDS dataset.
+
+    tag : str
+        Tag of the dataset.
+
+    changes_tag_entry : list
+        List of lines to be written to the `CHANGES` file.
+    """
+    # Read the current content of the CHANGES file
+    with open(os.path.join(bids_dir, "CHANGES"), "r") as f:
+        content = f.readlines()
+    # Create a new CHANGES file with the new release text block at the top
+    with open(os.path.join(bids_dir, "CHANGES"), "w") as f:
+        f.writelines(changes_tag_entry + content)

--- a/datahipy/handlers/dataset.py
+++ b/datahipy/handlers/dataset.py
@@ -20,7 +20,11 @@ try:
 except ImportError:
     print("WARNING: BIDS Manager Python package is not accessible.")
 
-from datahipy.bids.dataset import get_bidsdataset_content
+from datahipy.bids.dataset import (
+    get_bidsdataset_content,
+    create_initial_bids_changes,
+    create_initial_bids_readme,
+)
 
 
 class DatasetHandler:
@@ -55,11 +59,16 @@ class DatasetHandler:
         if not os.path.isfile(datasetdesc_path):
             # Write the dataset_description.json file
             datasetdesc_dict.write_file(jsonfilename=datasetdesc_path)
+            # Write an initial README.md file
+            create_initial_bids_readme(ds_path, datasetdesc_dict)
+            # Write an initial empty CHANGES file
+            create_initial_bids_changes(ds_path, content_lines=[])
             # Save the state of the dataset with Datalad
             save_params = {
                 "dataset": ds_path,
                 "message": "Initial BIDS dataset state",
                 "recursive": True,
+                # "version_tag": "0.0.0",  # Uncomment if you wish to create here a tag for the initial state
             }
             datalad.api.save(**save_params)
         # Load the created BIDS dataset in BIDS Manager (creates companion files)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'DataHIPy: Data Manager of the Human Intracerebral Platform in Python'
+html_title = "DataHIPy: Data Manager of the Human Intracerebral Platform in Python"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 html_short_title = "DataHIPy"

--- a/docs/examples/io/dataset_create_tag.json
+++ b/docs/examples/io/dataset_create_tag.json
@@ -1,5 +1,8 @@
 {
     "path": "/test/tmp/NEW_BIDS_DS",
+    "type": "bids",
     "tag": "1.0.0",
-    "message": "- Import sub-carole data"
+    "changes_list": [
+        "Import sub-carole data"
+    ]
 }

--- a/docs/examples/io/project_create_tag.json
+++ b/docs/examples/io/project_create_tag.json
@@ -1,5 +1,8 @@
 {
     "path": "/test/tmp/NEW_PROJECT",
+    "type": "project",
     "tag": "1.0.0",
-    "message": "- Import sub-carole data from existing dataset"
+    "changes_list": [
+        "Import sub-carole data from existing dataset"
+    ]
 }

--- a/test/cli/test_run_dataset.py
+++ b/test/cli/test_run_dataset.py
@@ -56,8 +56,9 @@ def test_run_dataset_create_init_tag(script_runner, dataset_path, io_path):
     # Create input data
     input_data = {
         "path": dataset_path,
+        "type": "bids",
         "tag": "0.0.0",
-        "message": "- Initial tag at dataset creation",
+        "changes_list": ["Initial tag at dataset creation"],
     }
     # Create JSON file path for input data
     input_file = os.path.join(io_path, "dataset_create_init_tag.json")
@@ -82,8 +83,9 @@ def test_run_dataset_create_tag(script_runner, dataset_path, io_path):
     # Create input data
     input_data = {
         "path": dataset_path,
+        "type": "bids",
         "tag": "1.0.0",
-        "message": "- Import sub-carole data",
+        "changes_list": ["Import sub-carole data"],
     }
     # Create JSON file path for input data
     input_file = os.path.join(io_path, "dataset_create_tag.json")

--- a/test/cli/test_run_project.py
+++ b/test/cli/test_run_project.py
@@ -80,8 +80,9 @@ def test_run_project_create_init_tag(script_runner, project_path, io_path):
     # Create input data
     input_data = {
         "path": project_path,
+        "type": "project",
         "tag": "0.0.0",
-        "message": "- Initial project",
+        "changes_list": ["Initial project"],
     }
     # Create JSON file path for input data
     input_file = os.path.join(io_path, "project_create_init_tag.json")
@@ -177,8 +178,9 @@ def test_run_project_create_tag(script_runner, project_path, io_path):
     # Create input data
     input_data = {
         "path": project_path,
+        "type": "project",
         "tag": "1.0.0",
-        "message": "- Import sub-carole data from existing dataset",
+        "changes_list": ["Import sub-carole data from existing dataset"],
     }
     # Create JSON file path for input data
     input_file = os.path.join(io_path, "project_create_tag.json")


### PR DESCRIPTION
This PR adjusts the `create_tag()` method and implements new methods in `datahipy.bids.dataset`, `datahipy.bids.version` and `datahipy.utils.versioning` to allow to write and update the `CHANGES` file of a BIDS dataset in the center space or in the space of a collaborative project.